### PR TITLE
fix: Fix detection of UBI devices.

### DIFF
--- a/libflash/platformfs.hpp
+++ b/libflash/platformfs.hpp
@@ -37,6 +37,8 @@ using Bytes = std::vector<uint8_t>;
 
 const int DEFAULT_FILE_PERMISSION = 0644;
 
+string BaseName(const string &path);
+
 ///
 /// \brief Create
 /// \param p: path


### PR DESCRIPTION
Apparently the device numbers are not stable, but are assigned at boot. Use `/sys` to determine what the device is instead, like the Golang Mender client does.

Changelog: Title
Ticket: MEN-7156