### PR TITLE
use 64bit filesystem offsets/sizes everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ add_library(crossplatform_compiler_flags INTERFACE)
 target_compile_features(crossplatform_compiler_flags INTERFACE cxx_std_11)
 target_compile_options(crossplatform_compiler_flags INTERFACE -std=c++11 -Werror -Wall -Wconversion)
 
+# use the 64bit variants of filesystem functions consistently. improves
+# compatibility with musl, which only exposes the 64bit variants, but without
+# the name suffix.
+target_compile_definitions(crossplatform_compiler_flags INTERFACE _FILE_OFFSET_BITS=64)
+
 add_library(platform_compiler_flags INTERFACE)
 target_compile_features(platform_compiler_flags INTERFACE cxx_std_17)
 target_compile_options(platform_compiler_flags INTERFACE -std=c++17 -Werror -Wall -Wconversion)

--- a/libflash/platformfs.cpp
+++ b/libflash/platformfs.cpp
@@ -160,7 +160,7 @@ Error mender::io::Flush(File f) {
 
 Error mender::io::SeekSet(mender::io::File f, uint64_t pos) {
 	errno = 0;
-	lseek64(f, pos, SEEK_SET);
+	lseek(f, pos, SEEK_SET);
 	if (errno != 0) {
 		std::stringstream ss;
 		ss << "Can't set seek on the file";
@@ -171,7 +171,7 @@ Error mender::io::SeekSet(mender::io::File f, uint64_t pos) {
 
 ExpectedSize64 mender::io::Tell(mender::io::File f) {
 	errno = 0;
-	int64_t pos = lseek64(f, 0, SEEK_CUR);
+	int64_t pos = lseek(f, 0, SEEK_CUR);
 	if (errno != 0) {
 		std::stringstream ss;
 		ss << "Error while getting file position";


### PR DESCRIPTION
this improves compatibility with musl, which only exposes the 64bit variants, but without the "64" name suffix.