### PR TITLE
RFC - fix: fixed an issue with UBI device detection

### DIFF
--- a/libflash/platformfs.cpp
+++ b/libflash/platformfs.cpp
@@ -39,7 +39,7 @@ string mender::io::BaseName(const string &path) {
 	if (pos == string::npos) {
 		return path;
 	} else {
-		return string {path.begin() + pos, path.end()};
+		return string {path.begin() + pos + 1, path.end()};
 	}
 }
 


### PR DESCRIPTION
The current implementation includes the slash character when extracting the basename from a path, which would create an invalid path when used in the `IsUBIDevice` function.
In the original implementation `return string {path.begin() + pos, path.end()};` was including the slash character in the returned string. For example, if the path was "/dev/ubi0", it would return "/ubi0" instead of just "ubi0".