### PR TITLE
chore: Do not always compile with `-fanalyzer`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,15 @@ tests:32bit:
     - make --jobs=$(nproc --all) --keep-going
     - make check
 
+tests:static-analysis:
+  stage: test
+  image: debian:12
+  before_script:
+    - apt update && apt install -yyq g++ g++-multilib cmake make lcov
+  script:
+    - cmake -D CMAKE_C_FLAGS="-fanalyzer" .
+    - make --jobs=$(nproc --all) --keep-going
+
 publish:coverage:
   stage: publish
   image: python:3.11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if($CACHE{COVERAGE})
   set(CMAKE_C_FLAGS "--coverage $CACHE{CMAKE_C_FLAGS}")
 endif()
 
-add_compile_options(-Wall -Wextra -Werror -fanalyzer)
+add_compile_options(-Wall -Wextra -Werror)
 add_executable(mender-flash main.c)
 
 install(TARGETS mender-flash


### PR DESCRIPTION
It would be really nice to do so, but then comes Ubuntu Jammy and this that here:

```
    if ((input_path == NULL) || (output_path == NULL)) {
        fprintf(stderr, "Wrong input parameters!\n");
        PrintHelp();
        return EXIT_FAILURE;
    }

    int in_fd;
    int out_fd;
    if (strcmp(input_path, "-") == 0) {
        in_fd = STDIN_FILENO;
```

`input_path` can be `NULL` in the `strcmp()` call.

Let's add a CI job to compile with static analysis on Debian 12 where we get no such false positives.

Ticket: none
Changelog: none