### PR TITLE
ci: replace coveralls with codecov

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,11 @@ include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-license.yml'
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/publish-codecov@master
+    inputs:
+      coverage_file: coverage.lcov
+      flag: unittests
+      needs_job: tests+coverage
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
@@ -58,34 +63,3 @@ tests:static-analysis:
   script:
     - cmake -D CMAKE_C_FLAGS="-fanalyzer" .
     - make --jobs=$(nproc --all) --keep-going
-
-publish:coverage:
-  stage: publish
-  allow_failure: true
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/python:3.11
-  dependencies:
-    - tests+coverage
-  before_script:
-    # Install dependencies
-    - !reference [.qa-common-network-apt-retry, before_script]
-    - apt update && apt install -yyq lcov
-    - pip install cpp-coveralls pyyaml
-
-    # eddyxu/cpp-coveralls appears dead, but there doesn't seem to be an
-    # alternative. Use this patch from someone who attempted to fix it. An
-    # alternative to this is to use pyyaml<6, but it's better to use just one
-    # old component than two.
-    - curl -f https://github.com/eddyxu/cpp-coveralls/commit/067c837c04e039e8c70aa53bceda1cded6751408.patch | patch -f /usr/local/lib/python3.11/site-packages/cpp_coveralls/__init__.py
-
-    - export CI_BRANCH=$CI_COMMIT_BRANCH
-    # "TRAVIS_JOB_ID" is hardcoded in cpp-coveralls, but it is semantically the
-    # same as "CI_JOB_ID" would be.
-    - export TRAVIS_JOB_ID=$CI_PIPELINE_ID
-
-  script:
-    - 'echo "service_name: gitlab-ci" > .coveralls.yml'
-    - cpp-coveralls
-      --repo-token ${COVERALLS_TOKEN}
-      --no-gcov
-      --lcov-file coverage.lcov
-


### PR DESCRIPTION
Drops the cpp-coveralls install and the upstream patch it needed in favour of the publish-codecov component and adds explicit coverage thresholds

Ticket: [QA-1573](https://northerntech.atlassian.net/browse/QA-1573)

[QA-1573]: https://northerntech.atlassian.net/browse/QA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ